### PR TITLE
Implement add-prefix option for convert:php

### DIFF
--- a/lib/Command/AbstractConvert.php
+++ b/lib/Command/AbstractConvert.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console;
 use Goetas\XML\XSDReader\SchemaReader;
 use Goetas\Xsd\XsdToPhp\AbstractConverter;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
 use Goetas\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 use Goetas\Xsd\XsdToPhp\Naming\LongNamingStrategy;
 use Goetas\Xsd\XsdToPhp\Naming\NamingStrategy;
@@ -117,10 +118,10 @@ abstract class AbstractConvert extends Console\Command\Command
             $schemas[spl_object_hash($schema)] = $schema;
         }
 
-        $this->convert($converter, $schemas, $targets, $output);
+        $this->convert($converter, $schemas, $targets, $input, $output);
 
         return 0;
     }
 
-    protected abstract function convert(AbstractConverter $converter, array $schemas, array $targets, OutputInterface $output);
+    protected abstract function convert(AbstractConverter $converter, array $schemas, array $targets, InputInterface $input, OutputInterface $output);
 }

--- a/lib/Command/ConvertToPHP.php
+++ b/lib/Command/ConvertToPHP.php
@@ -6,6 +6,8 @@ use Goetas\Xsd\XsdToPhp\Php\ClassGenerator;
 use Goetas\Xsd\XsdToPhp\Php\PathGenerator\Psr4PathGenerator;
 use Goetas\Xsd\XsdToPhp\AbstractConverter;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Zend\Code\Generator\FileGenerator;
 use Goetas\Xsd\XsdToPhp\Naming\NamingStrategy;
 
@@ -21,6 +23,7 @@ class ConvertToPHP extends AbstractConvert
         parent::configure();
         $this->setName('convert:php');
         $this->setDescription('Convert XSD definitions into PHP classes');
+        $this->addOption('add-prefix', null, InputOption::VALUE_REQUIRED, 'Set the prefix for the add-methods.', 'addTo');
     }
 
     protected function getConverterter(NamingStrategy $naming)
@@ -28,9 +31,11 @@ class ConvertToPHP extends AbstractConvert
         return new PhpConverter($naming);
     }
 
-    protected function convert(AbstractConverter $converter, array $schemas, array $targets, OutputInterface $output)
+    protected function convert(AbstractConverter $converter, array $schemas, array $targets, InputInterface $input, OutputInterface $output)
     {
         $generator = new ClassGenerator();
+        $generator->setAddPrefix($input->getOption('add-prefix'));
+
         $pathGenerator = new Psr4PathGenerator($targets);
         $progress = $this->getHelperSet()->get('progress');
 

--- a/lib/Command/ConvertToYaml.php
+++ b/lib/Command/ConvertToYaml.php
@@ -5,6 +5,7 @@ use Goetas\Xsd\XsdToPhp\Jms\PathGenerator\Psr4PathGenerator;
 use Goetas\Xsd\XsdToPhp\Jms\YamlConverter;
 use Symfony\Component\Yaml\Dumper;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
 use Goetas\Xsd\XsdToPhp\AbstractConverter;
 use Goetas\Xsd\XsdToPhp\Naming\NamingStrategy;
 
@@ -27,7 +28,7 @@ class ConvertToYaml extends AbstractConvert
         return new YamlConverter($naming);
     }
 
-    protected function convert(AbstractConverter $converter, array $schemas, array $targets, OutputInterface $output)
+    protected function convert(AbstractConverter $converter, array $schemas, array $targets, InputInterface $input, OutputInterface $output)
     {
         $items = $converter->convert($schemas);
 

--- a/lib/Php/ClassGenerator.php
+++ b/lib/Php/ClassGenerator.php
@@ -16,6 +16,26 @@ use Zend\Code\Generator\DocBlock\Tag\PropertyTag;
 
 class ClassGenerator
 {
+    /**
+     * @var string $addPrefix
+     */
+    private $addPrefix = 'addTo';
+
+    /**
+     * @return string
+     */
+    public function getAddPrefix()
+    {
+        return $this->addPrefix;
+    }
+
+    /**
+     * @param string $addPrefix
+     */
+    public function setAddPrefix($addPrefix)
+    {
+        $this->addPrefix = $addPrefix;
+    }
 
     private function handleBody(Generator\ClassGenerator $class, PHPClass $type)
     {
@@ -308,7 +328,7 @@ class ClassGenerator
             ->getType()));
         $docblock->setTag($patramTag);
 
-        $method = new MethodGenerator("addTo".Inflector::classify($prop->getName()));
+        $method = new MethodGenerator($this->getAddPrefix().Inflector::classify($prop->getName()));
 
         $parameter = new ParameterGenerator($propName);
         $tt = $type->getArg()->getType();

--- a/tests/PHP/PHPConversionTest.php
+++ b/tests/PHP/PHPConversionTest.php
@@ -12,14 +12,18 @@ class PHPConversionTest extends \PHPUnit_Framework_TestCase
     /**
      *
      * @param mixed $xml
+     * @param string $addPrefix
+     *
      * @return \Zend\Code\Generator\ClassGenerator[]
      */
-    protected function getClasses($xml)
+    protected function getClasses($xml, $addPrefix = 'addTo')
     {
         $phpcreator = new PhpConverter(new ShortNamingStrategy());
         $phpcreator->addNamespace('http://www.example.com', 'Example');
 
         $generator = new ClassGenerator();
+        $generator->setAddPrefix($addPrefix);
+
         $reader = new SchemaReader();
 
         if (! is_array($xml)) {
@@ -243,5 +247,36 @@ class PHPConversionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($single->hasMethod('getId'));
         $this->assertTrue($single->hasMethod('setId'));
+    }
+
+    public function testAddPrefix()
+    {
+        $xml = '
+            <xs:schema targetNamespace="http://www.example.com"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+                <xs:complexType name="ArrayOfStrings">
+                    <xs:all>
+                        <xs:element name="string" type="xs:string" maxOccurs="unbounded"/>
+                    </xs:all>
+                </xs:complexType>
+
+                <xs:complexType name="Single">
+                    <xs:all>
+                        <xs:element name="a" type="ArrayOfStrings"/>
+                        <xs:element name="b" type="ArrayOfStrings"/>
+                    </xs:all>
+                </xs:complexType>
+
+            </xs:schema>';
+
+        $items = $this->getClasses($xml, 'add');
+
+        $this->assertCount(1, $items);
+
+        $single = $items['Example\SingleType'];
+        $this->assertTrue($single->hasMethod('addA'));
+        $this->assertTrue($single->hasMethod('addB'));
+
     }
 }


### PR DESCRIPTION
Hello

When converting an XSD to PHP classes, you are using the addTo... notation to add multiple elements. I'm not a huge fan of this notation so I've made this configurable.

It is now possible to do this...
```
./bin/xsd2php convert:php example.xsd --ns-map='...' --ns-dest='...' --alias-map='...' --add-prefix='add'
```
...which will result in for example "addElement" instead of "addToElement".

If a developer does not provide the option, nothing will change and "addTo" will still be used.