### PR TITLE
Do not add the timezone twice.

### DIFF
--- a/lib/Jms/Handler/XmlSchemaDateHandler.php
+++ b/lib/Jms/Handler/XmlSchemaDateHandler.php
@@ -72,7 +72,7 @@ class XmlSchemaDateHandler implements SubscribingHandlerInterface
 
     public function serializeTime(XmlSerializationVisitor $visitor, \DateTime $date, array $type, Context $context)
     {
-        $v = $date->format('H:i:sP');
+        $v = $date->format('H:i:s');
         if ($date->getTimezone()->getOffset($date)!==$this->defaultTimezone->getOffset($date)){
             $v.= $date->format('P');
         }


### PR DESCRIPTION
The timezone (if present) was added twice when serializing time values.