### PR TITLE
Tag the bin script in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
             "Goetas\\Xsd\\XsdToPhp\\Tests\\":"tests/"
         }
     },
+    "bin": ["bin/xsd2php.php"],
     "extra":{
         "branch-alias":{
             "dev-master":"2.0-dev"


### PR DESCRIPTION
Clients can require xsd2php and run `vendor/bin/xsd2php` instead of searching the vendor folder.