### PR TITLE
fix code generation with empty (root) php namespace

### DIFF
--- a/lib/Php/ClassGenerator.php
+++ b/lib/Php/ClassGenerator.php
@@ -395,7 +395,7 @@ class ClassGenerator
         if ($type->getDoc()) {
             $docblock->setLongDescription($type->getDoc());
         }
-        $class->setNamespaceName($type->getNamespace());
+        $class->setNamespaceName($type->getNamespace() ?: NULL);
         $class->setName($type->getName());
         $class->setDocblock($docblock);
 


### PR DESCRIPTION
fix generated code when empty php namespace is set (`/`)

`xsd2php convert:php --ns-map="http://schema.example.com;/" --ns-dest="/;output/path" -- source-schema.xsd`