### PR TITLE
Additional naming strategies

### DIFF
--- a/lib/Command/AbstractConvert.php
+++ b/lib/Command/AbstractConvert.php
@@ -3,9 +3,7 @@ namespace Goetas\Xsd\XsdToPhp\Command;
 
 use Exception;
 use Goetas\Xsd\XsdToPhp\AbstractConverter;
-use Goetas\Xsd\XsdToPhp\Naming\LongNamingStrategy;
-use Goetas\Xsd\XsdToPhp\Naming\NamingStrategy;
-use Goetas\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
+use Goetas\Xsd\XsdToPhp\Naming;
 use GoetasWebservices\XML\XSDReader\SchemaReader;
 use Symfony\Component\Console;
 use Symfony\Component\Console\Input\InputArgument;
@@ -32,7 +30,7 @@ abstract class AbstractConvert extends Console\Command\Command
 
     /**
      */
-    protected abstract function getConverterter(NamingStrategy $naming);
+    protected abstract function getConverterter(Naming\NamingStrategy $naming);
 
     /**
      *
@@ -53,9 +51,13 @@ abstract class AbstractConvert extends Console\Command\Command
         }
 
         if ($input->getOption('naming-strategy') == 'short') {
-            $naming = new ShortNamingStrategy();
+            $naming = new Naming\ShortNamingStrategy();
         } elseif ($input->getOption('naming-strategy') == 'long') {
-            $naming = new LongNamingStrategy();
+            $naming = new Naming\LongNamingStrategy();
+        } elseif ($input->getOption('naming-strategy') == 'short-accurate-props') {
+            $naming = new Naming\ShortAccuratePropsNamingStrategy();
+        } elseif ($input->getOption('naming-strategy') == 'long-accurate-props') {
+            $naming = new Naming\LongAccuratePropsNamingStrategy();
         } else {
             throw new \InvalidArgumentException("Unsupported naming strategy");
         }

--- a/lib/Naming/LongAccuratePropsNamingStrategy.php
+++ b/lib/Naming/LongAccuratePropsNamingStrategy.php
@@ -1,0 +1,35 @@
+<?php
+namespace Goetas\Xsd\XsdToPhp\Naming;
+
+use Doctrine\Common\Inflector\Inflector;
+use GoetasWebservices\XML\XSDReader\Schema\Item;
+use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
+
+class LongAccuratePropsNamingStrategy implements NamingStrategy
+{
+
+    public function getTypeName(Type $type)
+    {
+        return $this->classify($type->getName()) . "Type";
+    }
+
+    public function getAnonymousTypeName(Type $type, $parentName)
+    {
+        return $this->classify($parentName) . "AnonymousType";
+    }
+
+    public function getItemName(Item $item)
+    {
+        return $this->classify($item->getName());
+    }
+
+    public function getPropertyName($item)
+    {
+        return $item->getName();
+    }
+
+    private function classify($name)
+    {
+        return Inflector::classify(str_replace(".", " ", $name));
+    }
+}

--- a/lib/Naming/ShortAccuratePropsNamingStrategy.php
+++ b/lib/Naming/ShortAccuratePropsNamingStrategy.php
@@ -1,0 +1,39 @@
+<?php
+namespace Goetas\Xsd\XsdToPhp\Naming;
+
+use Doctrine\Common\Inflector\Inflector;
+use GoetasWebservices\XML\XSDReader\Schema\Item;
+use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
+
+class ShortAccuratePropsNamingStrategy implements NamingStrategy
+{
+
+    public function getTypeName(Type $type)
+    {
+        $name = $this->classify($type->getName());
+        if ($name && substr($name, -4) !== 'Type') {
+            $name .= "Type";
+        }
+        return $name;
+    }
+
+    public function getAnonymousTypeName(Type $type, $parentName)
+    {
+        return $this->classify($parentName) . "AType";
+    }
+
+    public function getPropertyName($item)
+    {
+        return $item->getName();
+    }
+
+    public function getItemName(Item $item)
+    {
+        return $this->classify($item->getName());
+    }
+
+    private function classify($name)
+    {
+        return Inflector::classify(str_replace(".", " ", $name));
+    }
+}


### PR DESCRIPTION
Two naming strategies, which are use accurate properties naming from XSD. May be useful if you have `LikeThisOne` properties naming in XSD and you want same naming in generated classes.